### PR TITLE
Upgrade to gpt-4o and add test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ sniffio==1.3.1
 tqdm==4.66.2
 typing_extensions==4.10.0
 yarl==1.9.4
+openai==1.82.0

--- a/style_changer.py
+++ b/style_changer.py
@@ -17,7 +17,7 @@ def change_style(text, style):
     """
 
     completion = client.chat.completions.create(
-        model="gpt-3.5-turbo",
+        model="gpt-4o",
         messages=[
             {"role": "system", "content": "Pretend you are an expert author."},
             {"role": "user", "content": "Change the style of this document to " + style + ": " + text}

--- a/test_style_changer.py
+++ b/test_style_changer.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from style_changer import change_style
+
+class TestStyleChanger(unittest.TestCase):
+
+    @patch('style_changer.client.chat.completions.create')
+    def test_change_style(self, mock_create):
+        # Configure the mock response
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message = MagicMock()
+        mock_response.choices[0].message.content = "Mocked styled text."
+        mock_create.return_value = mock_response
+
+        # Call the function
+        text_to_change = "This is a test text."
+        style_to_apply = "Test Style"
+        result = change_style(text_to_change, style_to_apply)
+
+        # Assert the return value
+        self.assertEqual(result, "Mocked styled text.")
+
+        # Assert that the create method was called with the correct model
+        mock_create.assert_called_once_with(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": "Pretend you are an expert author."},
+                {"role": "user", "content": f"Change the style of this document to {style_to_apply}: {text_to_change}"}
+            ]
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change updates the program to use the `gpt-4o` model instead of `gpt-3.5-turbo`. It also includes the following:
- Adds `openai==1.82.0` to `requirements.txt`.
- Modifies `style_changer.py` to specify `gpt-4o`.
- Creates `test_style_changer.py` with a unit test for the `change_style` function, mocking the OpenAI API call and verifying the model parameter.